### PR TITLE
Update for Emissary 2.0.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # a8r-gitops-example
+
+This is the example repo for Ambassador Labs' [DCP Cloud Configuration Analysis](https://www.getambassador.io/docs/cloud/latest/config-analysis/quick-start/).
+
+To use it, check out the [Quick Start](https://www.getambassador.io/docs/cloud/latest/config-analysis/quick-start/) and fork this repo when indicated. Enjoy!

--- a/README.md
+++ b/README.md
@@ -3,3 +3,28 @@
 This is the example repo for Ambassador Labs' [DCP Cloud Configuration Analysis](https://www.getambassador.io/docs/cloud/latest/config-analysis/quick-start/).
 
 To use it, check out the [Quick Start](https://www.getambassador.io/docs/cloud/latest/config-analysis/quick-start/) and fork this repo when indicated. Enjoy!
+
+**IMPORTANT:**
+
+- You must be running Edge Stack or Emissary-ingress **2.0.5 or later** to use this 
+  example repo.
+- The `manifests` directory in this repo uses a _cleartext-only_ `Listener` and `Host`.
+  This is **not recommended for production use** but it greatly simplifies the setup for
+  the example.
+
+To apply this to your cluster:
+
+```shell
+kubectl create namespace gitops-demo && \
+kubectl apply -n gitops-demo -f ./manifests
+```
+
+at which point you'll be able to 
+
+```shell
+curl http://$AMBASSADOR_IP/backend/
+```
+
+for a Quote of the Moment, where `$AMBASSADOR_IP` is the IP address or hostname of the
+load balancer for your Edge Stack or Emissary-ingress.
+ 

--- a/manifests/listeners-and-wildcard-host.yaml
+++ b/manifests/listeners-and-wildcard-host.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Listener
+metadata:
+  name: ambassador-http-listener
+  namespace: gitops-demo
+spec:
+  port: 8080
+  protocol: HTTP
+  securityModel: INSECURE
+  hostBinding:
+    namespace:
+      from: ALL
+---
+apiVersion: getambassador.io/v3alpha1
+kind: Host
+metadata:
+  name: wildcard-host
+  namespace: gitops-demo
+spec:
+  hostname: "*"
+  requestPolicy:
+    insecure:
+      action: Route

--- a/manifests/quote.yaml
+++ b/manifests/quote.yaml
@@ -1,6 +1,6 @@
 ---
-apiVersion: x.getambassador.io/v3alpha1
-kind: AmbassadorMapping
+apiVersion: getambassador.io/v3alpha1
+kind: Mapping
 metadata:
   name: quote-backend
   namespace: gitops-demo


### PR DESCRIPTION
Update the manifests to use getambassador.io/v3alpha1, and to include Listeners and a Host.

Signed-off-by: Flynn <flynn@datawire.io>
